### PR TITLE
fix missing tags for polygon

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/geojson/DataSetBuilder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/geojson/DataSetBuilder.java
@@ -201,8 +201,9 @@ public class DataSetBuilder {
         }
         if (coordinates.size() == 1) {
             // create simple way
-            createWay(coordinates.get(0));
+            final Way way = createWay(coordinates.get(0));
 
+            fillTagsFromFeature(feature, way);
         } else if (coordinates.size() > 1) {
             // create multipolygon
             final Relation multipolygon = new Relation();


### PR DESCRIPTION
I noticed a polygon with only 1 way didn't have any tags, this codefix should resolve that.
Attached a testfile that didn't have it's properties imported.
[test.zip](https://github.com/Larry0ua/josm-geojson/files/454079/test.zip)
